### PR TITLE
update regexp

### DIFF
--- a/app/components/ChatBox.js
+++ b/app/components/ChatBox.js
@@ -58,7 +58,7 @@ function displayImage(text) {
 const MessageRender = ({ message }) => {
   const emojis = [];
   let match;
-  const regex1 = RegExp(/:[\-a-zA-Z_|+0-9]+:/g);
+  const regex1 = RegExp(/:[\-a-zA-Z_+0-9]+:/g);
   while ((match = regex1.exec(message)) !== null) {
     emojis.push(<Emoji emoji={match[0]} size={16} />);
   }

--- a/app/components/ChatBox.js
+++ b/app/components/ChatBox.js
@@ -58,7 +58,7 @@ function displayImage(text) {
 const MessageRender = ({ message }) => {
   const emojis = [];
   let match;
-  const regex1 = RegExp(/:[\-a-zA-Z_]+:/g);
+  const regex1 = RegExp(/:[\-a-zA-Z_|+0-9]+:/g);
   while ((match = regex1.exec(message)) !== null) {
     emojis.push(<Emoji emoji={match[0]} size={16} />);
   }


### PR DESCRIPTION
close https://github.com/status-im/status-js-desktop/issues/8#event-1997528827

![image](https://user-images.githubusercontent.com/6588340/49447203-833c6400-f808-11e8-89a2-2bf10e2b9a38.png)

Now thumbs up works from typing `:+1` (which is the text that is outputted from the emoji picker).
The problem was that the regexp used to match text before sending it to the emoji render component was too specific, looking - more or less - only for alpha/letter characters. I broadened its remit so that it would match the required emoji code (not with an exact match, but one that would match similar formulations too), and did so with an OR operator so that it would still keep some specificity (and efficiency - we don't want to send too many things to the emoji render component to attempt an exact match on).
I tested against a few other emojis, which still render. 
