### PR TITLE
Node version requirement can go up to 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -292,7 +292,7 @@
     "uuid": "^3.3.2"
   },
   "engines": {
-    "node": ">=10.x <11",
+    "node": ">=10.x <12",
     "yarn": ">=1.x"
   },
   "collective": {


### PR DESCRIPTION
The installation would fail on newer node installations for no particular reason other than a version constraint.